### PR TITLE
 FastAPI backend CORS Configuration .py

### DIFF
--- a/stackbit.config.ts
+++ b/stackbit.config.ts
@@ -1,0 +1,9 @@
+import { defineStackbitConfig } from '@stackbit/types';
+
+export default defineStackbitConfig({
+    "stackbitVersion": "~0.6.0",
+    "nodeVersion": "18",
+    "ssgName": "custom",
+    "contentSources": [],
+    "postInstallCommand": "npm i --no-save @stackbit/types"
+})


### PR DESCRIPTION
from fastapi.middleware.cors import CORSMiddleware

app.add_middleware(
    CORSMiddleware,
    allow_origins=["https://creative-sunshine-f27320.netlify.app"],
    allow_credentials=True,
    allow_methods=["*"],
    allow_headers=["*"],
)